### PR TITLE
Revert "Bump python from 3.9.7-slim to 3.10.0-slim"

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.10.0-slim
+FROM python:3.9.7-slim
 
 LABEL maintainer="miqm"
 


### PR DESCRIPTION
Reverts miqm/bicep-cli#4

Reverting as we should keep python minor version in sync with Azure CLI